### PR TITLE
Update Liberation integrations due to website update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,10 @@ jobs:
         working-directory: ./app
       - run: yarn test
         working-directory: ./app
+      - run: yarn
+        working-directory: ./extension
+      - run: yarn test
+        working-directory: ./extension
 
   # e2e
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update the liberation url matcher and the identifier creation
 - Update the iframe url
 
 ## [0.6.4]

--- a/extension/package.json
+++ b/extension/package.json
@@ -43,6 +43,7 @@
     "rootDir": "./src",
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/__mocks__/styleMock.js"
-    }
+    },
+    "testPathIgnorePatterns": ["<rootDir>/integrations/test.ts"]
   }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -8,6 +8,7 @@
     "start": "nodemon -w . -i node_modules -i dist -e js,ts,css,json,html -x 'yarn build'",
     "clean": "rm -rf dist *.zip",
     "build": "yarn webpack",
+    "test": "jest",
     "zip": "../scripts/build-extension.ci.sh"
   },
   "dependencies": {

--- a/extension/src/integrations/__tests__/liberation.test.ts
+++ b/extension/src/integrations/__tests__/liberation.test.ts
@@ -18,4 +18,13 @@ describe('liberation', () => {
 
     expect(identifier).toEqual('liberation:societe:2021-03-03:JCH6CMACYBGRXAFR7YWBCUZ4IE');
   });
+
+  it('url 2 with sub topic', () => {
+    const liberation = new Liberation();
+    const url =
+      'https://www.liberation.fr/culture/cinema/golden-globes-et-gueule-de-bois-20210225_IKIUEHFHXFA7RAI74HUOAFS4SI/';
+    const identifier = liberation.getIdentifier(url);
+
+    expect(identifier).toEqual('liberation:culture:2021-02-25:IKIUEHFHXFA7RAI74HUOAFS4SI');
+  });
 });

--- a/extension/src/integrations/__tests__/liberation.test.ts
+++ b/extension/src/integrations/__tests__/liberation.test.ts
@@ -3,9 +3,19 @@ import { Liberation } from '../liberation';
 describe('liberation', () => {
   it('url 1', () => {
     const liberation = new Liberation();
-    const url = 'https://www.liberation.fr/france/2020/11/21/loi-securite-globale-venir-ici-avec-la-peur-au-ventre-c-est-triste-pour-la-democratie_1806336';
+    const url =
+      'https://www.liberation.fr/france/2020/11/21/loi-securite-globale-venir-ici-avec-la-peur-au-ventre-c-est-triste-pour-la-democratie_1806336';
     const identifier = liberation.getIdentifier(url);
 
     expect(identifier).toEqual('liberation:france:2020-11-21:1806336');
+  });
+
+  it('url 2', () => {
+    const liberation = new Liberation();
+    const url =
+      'https://www.liberation.fr/societe/a-chalon-sur-saone-des-forains-sous-perfusion-reclament-des-reponses-concretes-20210303_JCH6CMACYBGRXAFR7YWBCUZ4IE/';
+    const identifier = liberation.getIdentifier(url);
+
+    expect(identifier).toEqual('liberation:societe:2021-03-03:JCH6CMACYBGRXAFR7YWBCUZ4IE');
   });
 });

--- a/extension/src/integrations/liberation.ts
+++ b/extension/src/integrations/liberation.ts
@@ -1,7 +1,8 @@
 import { Integration } from '../integration/IntegrationHost';
 
 export class Liberation implements Integration {
-  static LIBERATION_REGEXP = /liberation\.fr(\/[-a-z0-9]+)+\/[-a-z0-9]+_([A-Z0-9]+)/;
+  static LIBERATION_REGEXP_OLD = /liberation\.fr\/([-a-z]+)\/(\d{4}\/\d{2}\/\d{2})\/[-a-z0-9]+_([0-9]+)$/;
+  static LIBERATION_REGEXP = /liberation\.fr\/([-a-z]+)\/?.*\/[-a-z0-9]+-(\d{8})_([A-Z0-9]+)\/?$/;
 
   name = 'liberation';
   domains = ['www.liberation.fr'];
@@ -12,14 +13,23 @@ export class Liberation implements Integration {
   }
 
   getIdentifier(url: string) {
-    const match = Liberation.LIBERATION_REGEXP.exec(url);
+    const match = Liberation.LIBERATION_REGEXP_OLD.exec(url) ?? Liberation.LIBERATION_REGEXP.exec(url);
 
-    if (!match)
+    if (!match) {
       return null;
+    }
 
     const [, topic, date, id] = match;
 
-    return ['liberation', topic, date.replace(/\//g, '-'), id].join(':');
+    let formatedDate;
+
+    if (date.includes('/')) {
+      formatedDate = date.replace(/\//g, '-');
+    } else {
+      formatedDate = date.slice(0, 4) + '-' + date.slice(4, 6) + '-' + date.slice(6);
+    }
+
+    return ['liberation', topic, formatedDate, id].join(':');
   }
 
   onIFrameLoaded(iframe: HTMLIFrameElement) {

--- a/extension/src/integrations/liberation.ts
+++ b/extension/src/integrations/liberation.ts
@@ -1,14 +1,14 @@
 import { Integration } from '../integration/IntegrationHost';
 
 export class Liberation implements Integration {
-  static LIBERATION_REGEXP = /liberation\.fr\/([-a-z]+)\/(\d{4}\/\d{2}\/\d{2})\/[-a-z0-9]+_([0-9]+)$/;
+  static LIBERATION_REGEXP = /liberation\.fr(\/[-a-z0-9]+)+\/[-a-z0-9]+_([A-Z0-9]+)/;
 
   name = 'liberation';
   domains = ['www.liberation.fr'];
   type = 'append' as const;
 
   getElement() {
-    return document.getElementsByClassName('article-body')[0].closest('.container-column') as HTMLElement;
+    return document.getElementsByClassName('tag-container')[0] as HTMLElement;
   }
 
   getIdentifier(url: string) {


### PR DESCRIPTION
- update element selector
- update LIBERATION_REGEXP to match new url
 > previous url should keep working (tested with [this one](liberation.fr/france/2020/01/01/homeopathie-premiere-etape-vers-le-deremboursement-total_1771376))